### PR TITLE
Add white background to SVGs, to fix invisibility in dark mode

### DIFF
--- a/PYTHON-README.md
+++ b/PYTHON-README.md
@@ -120,7 +120,7 @@ In mathematical notation, you might see the `:=`, `=:` and `=` symbols being use
 
 For example, the following defines *x* to be another name for 2*kj*.
 
-![equals1](http://latex.codecogs.com/svg.latex?x%20%3A%3D%202kj)
+![equals1](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24x%20%3A%3D%202kj%24%7D)
 
 <!-- x := 2kj -->
 
@@ -141,7 +141,7 @@ def plus(x, y):
 
 The following, on the other hand, represents equality:
 
-![equals2](http://latex.codecogs.com/svg.latex?x%20%3D%202kj)
+![equals2](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24x%20%3D%202kj%24%7D)
 
 <!-- x = 2kj -->
 
@@ -164,7 +164,7 @@ It's important to know *when a falsehood ought to crash a program* vs. when you 
 
 A square root operation is of the form:
 
-![squareroot](http://latex.codecogs.com/svg.latex?%5Cleft%28%5Csqrt%7Bx%7D%5Cright%29%5E2%20%3D%20x)
+![squareroot](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24%5Cleft%28%5Csqrt%7Bx%7D%5Cright%29%5E2%20%3D%20x%24%7D)
 
 <!-- \left(\sqrt{x}\right)^2 = x -->
 
@@ -181,9 +181,9 @@ print(np.sqrt(2))
 
 ```
 
-Complex numbers are expressions of the form ![complex](http://latex.codecogs.com/svg.latex?a&space;&plus;&space;ib), where ![a](http://latex.codecogs.com/svg.latex?a) is the real part and ![b](http://latex.codecogs.com/svg.latex?b) is the imaginary part. The imaginary number ![i](http://latex.codecogs.com/svg.latex?i) is defined as:
+Complex numbers are expressions of the form ![complex](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24a&space;&plus;&space;ib%24%7D), where ![a](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24a%24%7D) is the real part and ![b](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24b%24%7D) is the imaginary part. The imaginary number ![i](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24i%24%7D) is defined as:
 
-![imaginary](http://latex.codecogs.com/svg.latex?i%3D%5Csqrt%7B-1%7D).
+![imaginary](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24i%3D%5Csqrt%7B-1%7D%24%7D).
 <!-- i=\sqrt{-1} -->
 
 Vanilla python has a `complex` constructor, and a standard module `cmath` for working with them. 
@@ -245,7 +245,7 @@ They might seem obvious, but it's important to understand the subtle differences
 
 Both symbols can represent simple multiplication of scalars. The following are equivalent:
 
-![dotcross1](http://latex.codecogs.com/svg.latex?5%20%5Ccdot%204%20%3D%205%20%5Ctimes%204)
+![dotcross1](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%245%20%5Ccdot%204%20%3D%205%20%5Ctimes%204%24%7D)
 
 <!-- 5 \cdot 4 = 5 \times 4 -->
 
@@ -257,7 +257,7 @@ result = 5 * 4
 
 Often, the multiplication sign is only used to avoid ambiguity (e.g. between two numbers). Here, we can omit it entirely:
 
-![dotcross2](http://latex.codecogs.com/svg.latex?3kj)
+![dotcross2](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%243kj%24%7D)
 
 <!-- 3kj -->
 
@@ -273,7 +273,7 @@ To denote multiplication of one vector with a scalar, or element-wise multiplica
 
 Let's take our earlier example but apply it to vectors. For element-wise vector multiplication, you might see an open dot `∘` to represent the [Hadamard product](https://en.wikipedia.org/wiki/Hadamard_product_%28matrices%29).<sup>[2]</sup>
 
-![dotcross3](http://latex.codecogs.com/svg.latex?3%5Cmathbf%7Bk%7D%5Ccirc%5Cmathbf%7Bj%7D)
+![dotcross3](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%243%5Cmathbf%7Bk%7D%5Ccirc%5Cmathbf%7Bj%7D%24%7D)
 
 <!-- 3\mathbf{k}\circ\mathbf{j} -->
 
@@ -316,7 +316,7 @@ def multiply_scalar(scalar, a):
 
 The dot symbol `·` can be used to denote the [*dot product*](https://en.wikipedia.org/wiki/Dot_product) of two vectors. Sometimes this is called the *scalar product* since it evaluates to a scalar.
 
-![dotcross4](http://latex.codecogs.com/svg.latex?%5Cmathbf%7Bk%7D%5Ccdot%20%5Cmathbf%7Bj%7D)
+![dotcross4](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24%5Cmathbf%7Bk%7D%5Ccdot%20%5Cmathbf%7Bj%7D%24%7D)
 
 <!-- \mathbf{k}\cdot \mathbf{j} -->
 
@@ -341,7 +341,7 @@ def dot(a, b):
 
 The cross symbol `×` can be used to denote the [*cross product*](https://en.wikipedia.org/wiki/Cross_product) of two vectors.
 
-![dotcross5](http://latex.codecogs.com/svg.latex?%5Cmathbf%7Bk%7D%5Ctimes%20%5Cmathbf%7Bj%7D)
+![dotcross5](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24%5Cmathbf%7Bk%7D%5Ctimes%20%5Cmathbf%7Bj%7D%24%7D)
 
 <!-- \mathbf{k}\times \mathbf{j} -->
 
@@ -375,7 +375,7 @@ Numpy.
 
 The big Greek `Σ` (Sigma) is for [Summation](https://en.wikipedia.org/wiki/Summation). In other words: summing up some numbers.
 
-![sigma](http://latex.codecogs.com/svg.latex?%5Csum_%7Bi%3D1%7D%5E%7B100%7Di)
+![sigma](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24%5Csum_%7Bi%3D1%7D%5E%7B100%7Di%24%7D)
 
 <!-- \sum_{i=1}^{100}i -->
 
@@ -400,7 +400,7 @@ def sum_to_n(n):
 
 Here is another example where the *i*, or the "what to sum," is different:
 
-![sum2](http://latex.codecogs.com/svg.latex?%5Csum_%7Bi%3D1%7D%5E%7B100%7D%282i&plus;1%29)
+![sum2](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24%5Csum_%7Bi%3D1%7D%5E%7B100%7D%282i&plus;1%29%24%7D)
 
 <!-- \sum_{i=1}^{100}(2i+1) -->
 
@@ -422,7 +422,7 @@ evaluate the right-most sigma first, unless the author has enclosed them in
 parentheses to alter the order. However, in the following case, since we are
 dealing with finite sums, the order does not matter.
 
-![sigma3](http://latex.codecogs.com/svg.latex?%5Csum_%7Bi%3D1%7D%5E%7B2%7D%5Csum_%7Bj%3D4%7D%5E%7B6%7D%283ij%29)
+![sigma3](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24%5Csum_%7Bi%3D1%7D%5E%7B2%7D%5Csum_%7Bj%3D4%7D%5E%7B6%7D%283ij%29%24%7D)
 
 <!-- \sum_{i=1}^{2}\sum_{j=4}^{6}(3ij) -->
 
@@ -445,7 +445,7 @@ The capital Pi or "Big Pi" is very similar to [Sigma](#sigma), except we are usi
 
 Take the following:
 
-![capitalPi](http://latex.codecogs.com/svg.latex?%5Cprod_%7Bi%3D1%7D%5E%7B6%7Di)
+![capitalPi](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24%5Cprod_%7Bi%3D1%7D%5E%7B6%7Di%24%7D)
 
 <!-- \prod_{i=1}^{6}i -->
 
@@ -495,7 +495,7 @@ These three features all describe the *length* of an object.
 
 #### absolute value 
 
-![pipes1](http://latex.codecogs.com/svg.latex?%5Cleft%20%7C%20x%20%5Cright%20%7C)
+![pipes1](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24%5Cleft%20%7C%20x%20%5Cright%20%7C%24%7D)
 
 <!-- \left | x \right | -->
 
@@ -508,7 +508,7 @@ abs(x)
 ```
 #### Euclidean norm
 
-![pipes4](http://latex.codecogs.com/svg.latex?%5Cleft%20%5C%7C%20%5Cmathbf%7Bv%7D%20%5Cright%20%5C%7C)
+![pipes4](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24%5Cleft%20%5C%7C%20%5Cmathbf%7Bv%7D%20%5Cright%20%5C%7C%24%7D)
 
 <!-- \left \| \mathbf{v} \right \| -->
 
@@ -516,7 +516,7 @@ For a vector **v**, `‖v‖` is the [Euclidean norm](https://en.wikipedia.org/w
 
 Often this is represented by double-bars to avoid ambiguity with the *absolute value* notation, but sometimes you may see it with single bars:
 
-![pipes2](http://latex.codecogs.com/svg.latex?%5Cleft%20%7C%20%5Cmathbf%7Bv%7D%20%5Cright%20%7C)
+![pipes2](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24%5Cleft%20%7C%20%5Cmathbf%7Bv%7D%20%5Cright%20%7C%24%7D)
 
 <!-- \left | \mathbf{v} \right | -->
 
@@ -554,7 +554,7 @@ Resources:
 
 #### determinant
 
-![pipes3](http://latex.codecogs.com/svg.latex?%5Cleft%20%7C%5Cmathbf%7BA%7D%20%5Cright%20%7C)
+![pipes3](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24%5Cleft%20%7C%5Cmathbf%7BA%7D%20%5Cright%20%7C%24%7D)
 
 <!-- \left |\mathbf{A}  \right | -->
 
@@ -592,7 +592,7 @@ The second matrix was the [**2D rotation**](https://en.wikipedia.org/wiki/Rotati
 
 In geometry, the "hat" symbol above a character is used to represent a [unit vector](https://en.wikipedia.org/wiki/Unit_vector). For example, here is the unit vector of **a**:
 
-![hat](http://latex.codecogs.com/svg.latex?%5Chat%7B%5Cmathbf%7Ba%7D%7D)
+![hat](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24%5Chat%7B%5Cmathbf%7Ba%7D%7D%24%7D)
 
 <!-- \hat{\mathbf{a}} -->
 
@@ -650,7 +650,7 @@ But it's actually **faster** on large input, because arrays.
 
 In set theory, the "element of" symbol `∈` and `∋` can be used to describe whether something is an element of a *set*. For example:
 
-![element1](http://latex.codecogs.com/svg.latex?A%3D%5Cleft%20%5C%7B3%2C9%2C14%7D%7B%20%5Cright%20%5C%7D%2C%203%20%5Cin%20A)
+![element1](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24A%3D%5Cleft%20%5C%7B3%2C9%2C14%7D%7B%20%5Cright%20%5C%7D%2C%203%20%5Cin%20A%24%7D)
 
 <!-- A=\left \{3,9,14}{  \right \}, 3 \in A -->
 
@@ -678,13 +678,13 @@ set([3,3,3,2,4,3,3,3,1,2,4,5,3])
 
 The backwards `∋` is the same, but the order changes:
 
-![element2](http://latex.codecogs.com/svg.latex?A%3D%5Cleft%20%5C%7B3%2C9%2C14%7D%7B%20%5Cright%20%5C%7D%2C%20A%20%5Cni%203)
+![element2](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24A%3D%5Cleft%20%5C%7B3%2C9%2C14%7D%7B%20%5Cright%20%5C%7D%2C%20A%20%5Cni%203%24%7D)
 
 <!-- A=\left \{3,9,14}{  \right \}, A \ni 3 -->
 
 You can also use the "not an element of" symbols `∉` and `∌` like so:
 
-![element3](http://latex.codecogs.com/svg.latex?A%3D%5Cleft%20%5C%7B3%2C9%2C14%7D%7B%20%5Cright%20%5C%7D%2C%206%20%5Cnotin%20A)
+![element3](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24A%3D%5Cleft%20%5C%7B3%2C9%2C14%7D%7B%20%5Cright%20%5C%7D%2C%206%20%5Cnotin%20A%24%7D)
 
 <!-- A=\left \{3,9,14}{  \right \}, 6 \notin A -->
 
@@ -696,7 +696,7 @@ You may see some some large [Blackboard](https://en.wikipedia.org/wiki/Blackboar
 
 For example, we might describe *k* to be an [element of](#element) the set `ℝ`. 
 
-![real](http://latex.codecogs.com/svg.latex?k%20%5Cin%20%5Cmathbb%7BR%7D)
+![real](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24k%20%5Cin%20%5Cmathbb%7BR%7D%24%7D)
 
 <!-- k \in \mathbb{R} -->
 
@@ -820,13 +820,13 @@ R = np.linspace(-2, 2, 100)
 
 A **function** transforms an input into an output value. For example, the following is a function:
 
-![function1](http://latex.codecogs.com/svg.latex?x%5E%7B2%7D)
+![function1](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24x%5E%7B2%7D%24%7D)
 
 <!-- x^{2} -->
 
 We can give this function a *name*. Commonly, we use `ƒ` to describe a function, but it could be named `A` or anything else.
 
-![function2](http://latex.codecogs.com/svg.latex?f%5Cleft%20%28x%20%5Cright%20%29%20%3D%20x%5E%7B2%7D)
+![function2](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24f%5Cleft%20%28x%20%5Cright%20%29%20%3D%20x%5E%7B2%7D%24%7D)
 
 <!-- f\left (x  \right ) = x^{2} -->
 
@@ -840,7 +840,7 @@ def square(x):
 
 Sometimes a function is not named, and instead the output is written.
 
-![function3](http://latex.codecogs.com/svg.latex?y%20%3D%20x%5E%7B2%7D)
+![function3](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24y%20%3D%20x%5E%7B2%7D%24%7D)
 
 <!-- y = x^{2} -->
 
@@ -865,7 +865,7 @@ lambda x: x**2
 
 Functions can also have multiple parameters, like in a programming language. These are known as *arguments* in mathematics, and the number of arguments a function takes is known as the *arity* of the function.
 
-![function4](http://latex.codecogs.com/svg.latex?f%28x%2Cy%29%20%3D%20%5Csqrt%7Bx%5E2%20&plus;%20y%5E2%7D)
+![function4](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24f%28x%2Cy%29%20%3D%20%5Csqrt%7Bx%5E2%20&plus;%20y%5E2%7D%24%7D)
 
 <!-- f(x,y) = \sqrt{x^2 + y^2} -->
 
@@ -892,7 +892,7 @@ Some functions will use different relationships depending on the input value, *x
 
 The following function *ƒ* chooses between two "sub functions" depending on the input value.
 
-![piecewise1](http://latex.codecogs.com/svg.latex?f%28x%29%3D%20%5Cbegin%7Bcases%7D%20%5Cfrac%7Bx%5E2-x%7D%7Bx%7D%2C%26%20%5Ctext%7Bif%20%7D%20x%5Cgeq%201%5C%5C%200%2C%20%26%20%5Ctext%7Botherwise%7D%20%5Cend%7Bcases%7D)
+![piecewise1](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24f%28x%29%3D%20%5Cbegin%7Bcases%7D%20%5Cfrac%7Bx%5E2-x%7D%7Bx%7D%2C%26%20%5Ctext%7Bif%20%7D%20x%5Cgeq%201%5C%5C%200%2C%20%26%20%5Ctext%7Botherwise%7D%20%5Cend%7Bcases%7D%24%7D)
 
 <!--    f(x)= 
 \begin{cases}
@@ -919,7 +919,7 @@ There are some function names that are ubiquitous in mathematics. For a programm
 
 One such example is the *sgn* function. This is the *signum* or *sign* function. Let's use [piecewise function](#piecewise-function) notation to describe it:
 
-![sgn](http://latex.codecogs.com/svg.latex?sgn%28x%29%20%3A%3D%20%5Cbegin%7Bcases%7D%20-1%26%20%5Ctext%7Bif%20%7D%20x%20%3C%200%5C%5C%200%2C%20%26%20%5Ctext%7Bif%20%7D%20%7Bx%20%3D%200%7D%5C%5C%201%2C%20%26%20%5Ctext%7Bif%20%7D%20x%20%3E%200%5C%5C%20%5Cend%7Bcases%7D)
+![sgn](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24sgn%28x%29%20%3A%3D%20%5Cbegin%7Bcases%7D%20-1%26%20%5Ctext%7Bif%20%7D%20x%20%3C%200%5C%5C%200%2C%20%26%20%5Ctext%7Bif%20%7D%20%7Bx%20%3D%200%7D%5C%5C%201%2C%20%26%20%5Ctext%7Bif%20%7D%20x%20%3E%200%5C%5C%20%5Cend%7Bcases%7D%24%7D)
 
 <!-- sgn(x) := 
 \begin{cases}
@@ -948,13 +948,13 @@ Other examples of such functions: *sin*, *cos*, *tan*.
 
 In some literature, functions may be defined with more explicit notation. For example, let's go back to the `square` function we mentioned earlier:
 
-![function2](http://latex.codecogs.com/svg.latex?f%5Cleft%20%28x%20%5Cright%20%29%20%3D%20x%5E%7B2%7D)
+![function2](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24f%5Cleft%20%28x%20%5Cright%20%29%20%3D%20x%5E%7B2%7D%24%7D)
 
 <!-- f\left (x  \right ) = x^{2} -->
 
 It might also be written in the following form:
 
-![mapsto](http://latex.codecogs.com/svg.latex?f%20%3A%20x%20%5Cmapsto%20x%5E2)
+![mapsto](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24f%20%3A%20x%20%5Cmapsto%20x%5E2%24%7D)
 
 <!-- f : x \mapsto x^2 -->
 
@@ -962,7 +962,7 @@ The arrow here with a tail typically means "maps to," as in *x maps to x<sup>2</
 
 Sometimes, when it isn't obvious, the notation will also describe the *domain* and *codomain* of the function. A more formal definition of *ƒ* might be written as:
 
-![funcnot](http://latex.codecogs.com/svg.latex?%5Cbegin%7Balign*%7D%20f%20%3A%26%5Cmathbb%7BR%7D%20%5Crightarrow%20%5Cmathbb%7BR%7D%5C%5C%20%26x%20%5Cmapsto%20x%5E2%20%5Cend%7Balign*%7D)
+![funcnot](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24%5Cbegin%7Balign*%7D%20f%20%3A%26%5Cmathbb%7BR%7D%20%5Crightarrow%20%5Cmathbb%7BR%7D%5C%5C%20%26x%20%5Cmapsto%20x%5E2%20%5Cend%7Balign*%7D%24%7D)
 
 <!-- \begin{align*}
 f :&\mathbb{R} \rightarrow \mathbb{R}\\
@@ -972,7 +972,7 @@ f :&\mathbb{R} \rightarrow \mathbb{R}\\
 
 A function's *domain* and *codomain* is a bit like its *input* and *output* types, respectively. Here's another example, using our earlier *sgn* function, which outputs an integer:
 
-![domain2](http://latex.codecogs.com/svg.latex?sgn%20%3A%20%5Cmathbb%7BR%7D%20%5Crightarrow%20%5Cmathbb%7BZ%7D)
+![domain2](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24sgn%20%3A%20%5Cmathbb%7BR%7D%20%5Crightarrow%20%5Cmathbb%7BZ%7D%24%7D)
 
 <!-- sgn : \mathbb{R} \rightarrow \mathbb{Z} -->
 
@@ -1025,13 +1025,13 @@ In code, we typically just assign the variable a more descriptive name, like `tr
 
 For a mathematical [function](#function), the prime symbol often describes the *derivative* of that function. Derivatives will be explained in a future section. Let's take our earlier function:
 
-![function2](http://latex.codecogs.com/svg.latex?f%5Cleft%20%28x%20%5Cright%20%29%20%3D%20x%5E%7B2%7D)
+![function2](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24f%5Cleft%20%28x%20%5Cright%20%29%20%3D%20x%5E%7B2%7D%24%7D)
 
 <!-- f\left (x  \right ) = x^{2} -->
 
 Its derivative could be written with a prime `′` symbol:
 
-![prime1](http://latex.codecogs.com/svg.latex?f%27%28x%29%20%3D%202x)
+![prime1](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24f%27%28x%29%20%3D%202x%24%7D)
 
 <!-- f'(x) = 2x -->
 
@@ -1051,11 +1051,11 @@ Multiple prime symbols can be used to describe the second derivative *ƒ′′* 
 
 The special brackets `⌊x⌋` and `⌈x⌉` represent the *floor* and *ceil* functions, respectively.
 
-![floor](http://latex.codecogs.com/svg.latex?floor%28x%29%20%3D%20%5Clfloor%20x%20%5Crfloor)
+![floor](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24floor%28x%29%20%3D%20%5Clfloor%20x%20%5Crfloor%24%7D)
 
 <!-- floor(x) =  \lfloor x \rfloor -->
 
-![ceil](http://latex.codecogs.com/svg.latex?ceil%28x%29%20%3D%20%5Clceil%20x%20%5Crceil)
+![ceil](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24ceil%28x%29%20%3D%20%5Clceil%20x%20%5Crceil%24%7D)
 
 <!-- ceil(x) =  \lceil x \rceil -->
 
@@ -1073,7 +1073,7 @@ np.ceil(3.001)
 
 When the two symbols are mixed `⌊x⌉`, it typically represents a function that rounds to the nearest integer:
 
-![round](http://latex.codecogs.com/svg.latex?round%28x%29%20%3D%20%5Clfloor%20x%20%5Crceil)
+![round](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24round%28x%29%20%3D%20%5Clfloor%20x%20%5Crceil%24%7D)
 
 <!-- round(x) =  \lfloor x \rceil -->
 
@@ -1087,7 +1087,7 @@ Arrows are often used in [function notation](#function-notation). Here are a few
 
 Arrows like `⇒` and `→` are sometimes used in logic for *material implication.* That is, if A is true, then B is also true.
 
-![material1](http://latex.codecogs.com/svg.latex?A%20%5CRightarrow%20B)
+![material1](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24A%20%5CRightarrow%20B%24%7D)
 
 <!-- A \Rightarrow B -->
 
@@ -1102,7 +1102,7 @@ def if_A_then_B:
 
 The arrows can go in either direction `⇐` `⇒`, or both `⇔`. When *A ⇒ B* and *B ⇒ A*, they are said to be equivalent:
 
-![material-equiv](http://latex.codecogs.com/svg.latex?A%20%5CLeftrightarrow%20B)
+![material-equiv](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24A%20%5CLeftrightarrow%20B%24%7D)
 
 <!-- A \Leftrightarrow B -->
 
@@ -1119,7 +1119,7 @@ assert 4 >= 4
 
 On rare occasions you might see a slash through these symbols, to describe *not*. As in, *k* is "not greater than" *j*.
 
-![ngt](http://latex.codecogs.com/svg.latex?k%20%5Cngtr%20j)
+![ngt](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24k%20%5Cngtr%20j%24%7D)
 
 <!-- k \ngtr j -->
 
@@ -1130,7 +1130,7 @@ Sometimes read "beats", when I say `x^k ≫ log(x)` what I'm really saying is th
 "polynomial functions grow an order of magnitude faster than logarithms; in a
 word, the polynomial *beats* the logarithm."
 
-![orderofmag](http://latex.codecogs.com/svg.latex?k%20%5Cgg%20j)
+![orderofmag](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24k%20%5Cgg%20j%24%7D)
 
 <!-- k \gg j -->
 
@@ -1140,7 +1140,7 @@ Another use of arrows in logic is conjunction `∧` and disjunction `∨`. They 
 
 The following shows conjunction `∧`, the logical `AND`.
 
-![and](http://latex.codecogs.com/svg.latex?k%20%3E%202%20%5Cland%20k%20%3C%204%20%5CLeftrightarrow%20k%20%3D%203)
+![and](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24k%20%3E%202%20%5Cland%20k%20%3C%204%20%5CLeftrightarrow%20k%20%3D%203%24%7D)
 
 <!-- k > 2 \land k <  4 \Leftrightarrow k = 3   -->
 
@@ -1158,7 +1158,7 @@ lambda k: if (k == 3): assert (k > 2 and k < 4), "I mean it, think through this 
 
 The down arrow `∨` is logical disjunction, like the OR operator.
 
-![logic-or](http://latex.codecogs.com/svg.latex?A%20%5Clor%20B)
+![logic-or](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24A%20%5Clor%20B%24%7D)
 
 <!-- A \lor B -->
 
@@ -1171,7 +1171,7 @@ Occasionally, the `¬`, `~` and `!` symbols are used to represent logical `NOT`.
 
 Here is a simple example using the *not* symbol:
 
-![negation](http://latex.codecogs.com/svg.latex?x%20%5Cneq%20y%20%5CLeftrightarrow%20%5Clnot%28x%20%3D%20y%29)
+![negation](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24x%20%5Cneq%20y%20%5CLeftrightarrow%20%5Clnot%28x%20%3D%20y%29%24%7D)
 
 <!-- x \neq y \Leftrightarrow \lnot(x = y) -->
 
@@ -1189,25 +1189,25 @@ Sometimes a function deals with real numbers restricted to some range of values,
 
 For example we can represent the numbers between zero and one including/not including zero and/or one as:
 
-- Not including zero or one: ![interval-opened-left-opened-right](http://latex.codecogs.com/svg.latex?%280%2C%201%29)
+- Not including zero or one: ![interval-opened-left-opened-right](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24%280%2C%201%29%24%7D)
 
 <!-- (0, 1) -->
 
-- Including zero or but not one: ![interval-closed-left-opened-right](http://latex.codecogs.com/svg.latex?%5B0%2C%201%29)
+- Including zero or but not one: ![interval-closed-left-opened-right](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24%5B0%2C%201%29%24%7D)
 
 <!-- [0, 1) -->
 
-- Not including zero but including one: ![interval-opened-left-closed-right](http://latex.codecogs.com/svg.latex?%280%2C%201%5D)
+- Not including zero but including one: ![interval-opened-left-closed-right](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24%280%2C%201%5D%24%7D)
 
 <!-- (0, 1] -->
 
-- Including zero and one: ![interval-closed-left-closed-right](http://latex.codecogs.com/svg.latex?%5B0%2C%201%5D)
+- Including zero and one: ![interval-closed-left-closed-right](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24%5B0%2C%201%5D%24%7D)
 
 <!-- [0, 1] -->
 
 For example we to indicate that a point `x` is in the unit cube in 3D we say:
 
-![interval-unit-cube](http://latex.codecogs.com/svg.latex?x%20%5Cin%20%5B0%2C%201%5D%5E3)
+![interval-unit-cube](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24x%20%5Cin%20%5B0%2C%201%5D%5E3%24%7D)
 
 <!-- x \in [0, 1]^3 -->
 
@@ -1219,15 +1219,15 @@ if you want to play with *infinite lists* in Python, learn more about [generator
 
 Intervals are used in conjunction with set operations:
 
-- *intersection* e.g. ![interval-intersection](http://latex.codecogs.com/svg.latex?%5B3%2C%205%29%20%5Ccap%20%5B4%2C%206%5D%20%3D%20%5B4%2C%205%29)
+- *intersection* e.g. ![interval-intersection](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24%5B3%2C%205%29%20%5Ccap%20%5B4%2C%206%5D%20%3D%20%5B4%2C%205%29%24%7D)
 
 <!-- [3, 5) \cap [4, 6] = [4, 5) -->
 
-- *union* e.g. ![interval-union](http://latex.codecogs.com/svg.latex?%5B3%2C%205%29%20%5Ccup%20%5B4%2C%206%5D%20%3D%20%5B3%2C%206%5D)
+- *union* e.g. ![interval-union](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24%5B3%2C%205%29%20%5Ccup%20%5B4%2C%206%5D%20%3D%20%5B3%2C%206%5D%24%7D)
 
 <!-- [3, 5) \cup [4, 6] = [3, 6] -->
 
-- *difference* e.g. ![interval-difference-1](http://latex.codecogs.com/svg.latex?%5B3%2C%205%29%20-%20%5B4%2C%206%5D%20%3D%20%5B3%2C%204%29) and ![interval-difference-2](http://latex.codecogs.com/svg.latex?%5B4%2C%206%5D%20-%20%5B3%2C%205%29%20%3D%20%5B5%2C%206%5D)
+- *difference* e.g. ![interval-difference-1](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24%5B3%2C%205%29%20-%20%5B4%2C%206%5D%20%3D%20%5B3%2C%204%29%24%7D) and ![interval-difference-2](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24%5B4%2C%206%5D%20-%20%5B3%2C%205%29%20%3D%20%5B5%2C%206%5D%24%7D)
 
 <!-- [3, 5) - [4, 6] = [3, 4) -->
 <!-- [4, 6] - [3, 5)  = [5, 6] -->

--- a/README-zh.md
+++ b/README-zh.md
@@ -93,7 +93,7 @@ function almostEqual(a, b, epsilon) {
 
 例如，下边定义 *x* 为 2*kj* 的别名。
 
-![equals1](http://latex.codecogs.com/svg.latex?x%20%3A%3D%202kj)
+![equals1](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24x%20%3A%3D%202kj%24%7D)
 
 <!-- x := 2kj -->
 
@@ -113,7 +113,7 @@ const f = (k, j) => 2 * k * j
 
 与此不同的是，下边这句表示的是相等：
 
-![equals2](http://latex.codecogs.com/svg.latex?x%20%3D%202kj)
+![equals2](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24x%20%3D%202kj%24%7D)
 
 <!-- x = 2kj -->
 
@@ -127,7 +127,7 @@ console.assert(x === (2 * k * j))
 
 一个平方根运算是这种形式:
 
-![squareroot](http://latex.codecogs.com/svg.latex?%5Cleft%28%5Csqrt%7Bx%7D%5Cright%29%5E2%20%3D%20x)
+![squareroot](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24%5Cleft%28%5Csqrt%7Bx%7D%5Cright%29%5E2%20%3D%20x%24%7D)
 
 <!-- \left(\sqrt{x}\right)^2 = x -->
 
@@ -139,9 +139,9 @@ console.log(Math.sqrt(x));
 //=> 3
 ```
 
-复数是 ![complex](http://latex.codecogs.com/svg.latex?a&space;&plus;&space;ib) 形式的表达式， 其中 ![a](http://latex.codecogs.com/svg.latex?a) 是实数部分， ![b](http://latex.codecogs.com/svg.latex?b) 是虚数部分。 虚数 ![i](http://latex.codecogs.com/svg.latex?i) 的定义为：
+复数是 ![complex](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24a&space;&plus;&space;ib%24%7D) 形式的表达式， 其中 ![a](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24a%24%7D) 是实数部分， ![b](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24b%24%7D) 是虚数部分。 虚数 ![i](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24i%24%7D) 的定义为：
 
-![imaginary](http://latex.codecogs.com/svg.latex?i%3D%5Csqrt%7B-1%7D).
+![imaginary](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24i%3D%5Csqrt%7B-1%7D%24%7D).
 <!-- i=\sqrt{-1} -->
 
 JavaScript没有内置复数的功能，但有一些库支持复数算法。例如， [mathjs](https://www.npmjs.com/package/mathjs):
@@ -182,7 +182,7 @@ console.log(math.eval('(3 - i) * i').toString())
 
 两个符号都可以表示简单的标量之间的乘法。下边的写法意思相同：
 
-![dotcross1](http://latex.codecogs.com/svg.latex?5%20%5Ccdot%204%20%3D%205%20%5Ctimes%204)
+![dotcross1](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%245%20%5Ccdot%204%20%3D%205%20%5Ctimes%204%24%7D)
 
 <!-- 5 \cdot 4 = 5 \times 4 -->
 
@@ -194,7 +194,7 @@ var result = 5 * 4
 
 通常，使用乘法符号只是为了避免意义模糊（例如两个数字之间的）。这里，我们可以完全省略：
 
-![dotcross2](http://latex.codecogs.com/svg.latex?3kj)
+![dotcross2](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%243kj%24%7D)
 
 <!-- 3kj -->
 
@@ -210,7 +210,7 @@ var result = 3 * k * j
 
 让我们用之前的例子，但用在向量上。对于向量的逐元素相乘（element-wise vector multiplication）来说，你可能会看到用一个空心点来表示 [Hadamard product](https://en.wikipedia.org/wiki/Hadamard_product_%28matrices%29)。<sup>[2]</sup>
 
-![dotcross3](http://latex.codecogs.com/svg.latex?3%5Cmathbf%7Bk%7D%5Ccirc%5Cmathbf%7Bj%7D)
+![dotcross3](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%243%5Cmathbf%7Bk%7D%5Ccirc%5Cmathbf%7Bj%7D%24%7D)
 
 <!-- 3\mathbf{k}\circ\mathbf{j} -->
 
@@ -246,7 +246,7 @@ function multiplyScalar(a, scalar) {
 
 点符号 `·` 可用来表示两向量之间的 [*点乘*](https://en.wikipedia.org/wiki/Dot_product) 。 由于其值是一个标量，通常被叫做 *标量积（scalar product）* 。
 
-![dotcross4](http://latex.codecogs.com/svg.latex?%5Cmathbf%7Bk%7D%5Ccdot%20%5Cmathbf%7Bj%7D)
+![dotcross4](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24%5Cmathbf%7Bk%7D%5Ccdot%20%5Cmathbf%7Bj%7D%24%7D)
 
 <!-- \mathbf{k}\cdot \mathbf{j} -->
 
@@ -272,7 +272,7 @@ function dot(a, b) {
 
 叉乘符号 `×` 可以用来表示两向量的 [*叉乘*](https://en.wikipedia.org/wiki/Cross_product)。
 
-![dotcross5](http://latex.codecogs.com/svg.latex?%5Cmathbf%7Bk%7D%5Ctimes%20%5Cmathbf%7Bj%7D)
+![dotcross5](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24%5Cmathbf%7Bk%7D%5Ctimes%20%5Cmathbf%7Bj%7D%24%7D)
 
 <!-- \mathbf{k}\times \mathbf{j} -->
 
@@ -312,7 +312,7 @@ function cross(a, b) {
 
 大写希腊字母 `Σ` (Sigma) 用来表示 [总和 Summation](https://en.wikipedia.org/wiki/Summation)。 换句话说就是对一些数字求和。
 
-![sigma](http://latex.codecogs.com/svg.latex?%5Csum_%7Bi%3D1%7D%5E%7B100%7Di)
+![sigma](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24%5Csum_%7Bi%3D1%7D%5E%7B100%7Di%24%7D)
 
 <!-- \sum_{i=1}^{100}i -->
 
@@ -336,7 +336,7 @@ var sum = (n * (n + 1)) / 2
 
 这里有另一个例子，这里的 *i* ，或 “想要求和的东西” 是不同的：
 
-![sum2](http://latex.codecogs.com/svg.latex?%5Csum_%7Bi%3D1%7D%5E%7B100%7D%282i&plus;1%29)
+![sum2](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24%5Csum_%7Bi%3D1%7D%5E%7B100%7D%282i&plus;1%29%24%7D)
 
 <!-- \sum_{i=1}^{100}(2i+1) -->
 
@@ -353,7 +353,7 @@ for (var i = 1; i <= 100; i++) {
 
 这个符号可被嵌套，非常像嵌套一个 `for` 循环。 你应该先求和最右边的西格玛， 除非作者加入括号改变了顺序。然而下边的例子，由于我们处理有限的和，顺序就不重要了。
 
-![sigma3](http://latex.codecogs.com/svg.latex?%5Csum_%7Bi%3D1%7D%5E%7B2%7D%5Csum_%7Bj%3D4%7D%5E%7B6%7D%283ij%29)
+![sigma3](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24%5Csum_%7Bi%3D1%7D%5E%7B2%7D%5Csum_%7Bj%3D4%7D%5E%7B6%7D%283ij%29%24%7D)
 
 <!-- \sum_{i=1}^{2}\sum_{j=4}^{6}(3ij) -->
 
@@ -376,7 +376,7 @@ for (var i = 1; i <= 2; i++) {
 
 看下边：
 
-![capitalPi](http://latex.codecogs.com/svg.latex?%5Cprod_%7Bi%3D1%7D%5E%7B6%7Di)
+![capitalPi](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24%5Cprod_%7Bi%3D1%7D%5E%7B6%7Di%24%7D)
 
 <!-- \prod_{i=1}^{6}i -->
 
@@ -399,7 +399,7 @@ for (var i = 1; i <= 6; i++) {
 
 #### 绝对值
 
-![pipes1](http://latex.codecogs.com/svg.latex?%5Cleft%20%7C%20x%20%5Cright%20%7C)
+![pipes1](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24%5Cleft%20%7C%20x%20%5Cright%20%7C%24%7D)
 
 <!-- \left | x \right | -->
 
@@ -413,7 +413,7 @@ var result = Math.abs(x)
 
 #### 欧几里得模（Euclidean norm）
 
-![pipes4](http://latex.codecogs.com/svg.latex?%5Cleft%20%5C%7C%20%5Cmathbf%7Bv%7D%20%5Cright%20%5C%7C)
+![pipes4](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24%5Cleft%20%5C%7C%20%5Cmathbf%7Bv%7D%20%5Cright%20%5C%7C%24%7D)
 
 <!-- \left \| \mathbf{v} \right \| -->
 
@@ -421,7 +421,7 @@ var result = Math.abs(x)
 
 通常用双竖线表示来避免与*绝对值* 符号混淆，但有些时候也会看见单竖线。
 
-![pipes2](http://latex.codecogs.com/svg.latex?%5Cleft%20%7C%20%5Cmathbf%7Bv%7D%20%5Cright%20%7C)
+![pipes2](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24%5Cleft%20%7C%20%5Cmathbf%7Bv%7D%20%5Cright%20%7C%24%7D)
 
 <!-- \left | \mathbf{v} \right | -->
 
@@ -452,7 +452,7 @@ function length (vec) {
 
 #### 行列式
 
-![pipes3](http://latex.codecogs.com/svg.latex?%5Cleft%20%7C%5Cmathbf%7BA%7D%20%5Cright%20%7C)
+![pipes3](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24%5Cleft%20%7C%5Cmathbf%7BA%7D%20%5Cright%20%7C%24%7D)
 
 <!-- \left |\mathbf{A}  \right | -->
 
@@ -480,7 +480,7 @@ var det = determinant(matrix)
 
 在几何里，字母上的 “帽子” 符号用来表示一个[单位向量](https://en.wikipedia.org/wiki/Unit_vector)。例如，这是向量 **a** 的单位向量。
 
-![hat](http://latex.codecogs.com/svg.latex?%5Chat%7B%5Cmathbf%7Ba%7D%7D)
+![hat](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24%5Chat%7B%5Cmathbf%7Ba%7D%7D%24%7D)
 
 <!-- \hat{\mathbf{a}} -->
 
@@ -520,7 +520,7 @@ function normalize(vec) {
 
 集合理论中，“属于”符号 `∈` 和 `∋` 可以被用来描述某物是否为集合中的一个元素。例如：
 
-![element1](http://latex.codecogs.com/svg.latex?A%3D%5Cleft%20%5C%7B3%2C9%2C14%7D%7B%20%5Cright%20%5C%7D%2C%203%20%5Cin%20A)
+![element1](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24A%3D%5Cleft%20%5C%7B3%2C9%2C14%7D%7B%20%5Cright%20%5C%7D%2C%203%20%5Cin%20A%24%7D)
 
 <!-- A=\left \{3,9,14}{  \right \}, 3 \in A -->
 
@@ -546,13 +546,13 @@ A.has(3)
 
 反向的 `∋` 意义相同，只是顺序改变：
 
-![element2](http://latex.codecogs.com/svg.latex?A%3D%5Cleft%20%5C%7B3%2C9%2C14%7D%7B%20%5Cright%20%5C%7D%2C%20A%20%5Cni%203)
+![element2](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24A%3D%5Cleft%20%5C%7B3%2C9%2C14%7D%7B%20%5Cright%20%5C%7D%2C%20A%20%5Cni%203%24%7D)
 
 <!-- A=\left \{3,9,14}{  \right \}, A \ni 3 -->
 
 你可以使用 "不属于" 符号 `∉` 和 `∌` 像这样：
 
-![element3](http://latex.codecogs.com/svg.latex?A%3D%5Cleft%20%5C%7B3%2C9%2C14%7D%7B%20%5Cright%20%5C%7D%2C%206%20%5Cnotin%20A)
+![element3](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24A%3D%5Cleft%20%5C%7B3%2C9%2C14%7D%7B%20%5Cright%20%5C%7D%2C%206%20%5Cnotin%20A%24%7D)
 
 <!-- A=\left \{3,9,14}{  \right \}, 6 \notin A -->
 
@@ -562,7 +562,7 @@ A.has(3)
 
 例如，我们可以描述 *k* 是[属于](#属于) `ℝ` 集的一个元素。
 
-![real](http://latex.codecogs.com/svg.latex?k%20%5Cin%20%5Cmathbb%7BR%7D)
+![real](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24k%20%5Cin%20%5Cmathbb%7BR%7D%24%7D)
 
 <!-- k \in \mathbb{R} -->
 
@@ -629,13 +629,13 @@ function isNaturalNumber (n) {
 
 函数把输入输出值联系起来。例如下边是一个函数：
 
-![function1](http://latex.codecogs.com/svg.latex?x%5E%7B2%7D)
+![function1](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24x%5E%7B2%7D%24%7D)
 
 <!-- x^{2} -->
 
 我们可以给函数一个 *名字* 。一般来说我们用  `ƒ` 来描述一个函数，但也可以命名为 `A(x)` 或其他什么。
 
-![function2](http://latex.codecogs.com/svg.latex?f%5Cleft%20%28x%20%5Cright%20%29%20%3D%20x%5E%7B2%7D)
+![function2](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24f%5Cleft%20%28x%20%5Cright%20%29%20%3D%20x%5E%7B2%7D%24%7D)
 
 <!-- f\left (x  \right ) = x^{2} -->
 
@@ -649,7 +649,7 @@ function square (x) {
 
 有时函数没有名字，而是直接写出输出值。
 
-![function3](http://latex.codecogs.com/svg.latex?y%20%3D%20x%5E%7B2%7D)
+![function3](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24y%20%3D%20x%5E%7B2%7D%24%7D)
 
 <!-- y = x^{2} -->
 
@@ -657,7 +657,7 @@ function square (x) {
 
 像编程语言一样，函数也可以有多个参数。他们在数学中被称为 *arguments*，并且函数接受的参数数量被称为函数的 *arity* 。
 
-![function4](http://latex.codecogs.com/svg.latex?f%28x%2Cy%29%20%3D%20%5Csqrt%7Bx%5E2%20&plus;%20y%5E2%7D)
+![function4](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24f%28x%2Cy%29%20%3D%20%5Csqrt%7Bx%5E2%20&plus;%20y%5E2%7D%24%7D)
 
 <!-- f(x,y) = \sqrt{x^2 + y^2} -->
 
@@ -675,7 +675,7 @@ function length (x, y) {
 
 下边的函数 *f* 根据不同的输入值选择两个不同的“子函数”。
 
-![piecewise1](http://latex.codecogs.com/svg.latex?f%28x%29%3D%20%5Cbegin%7Bcases%7D%20%5Cfrac%7Bx%5E2-x%7D%7Bx%7D%2C%26%20%5Ctext%7Bif%20%7D%20x%5Cgeq%201%5C%5C%200%2C%20%26%20%5Ctext%7Botherwise%7D%20%5Cend%7Bcases%7D)
+![piecewise1](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24f%28x%29%3D%20%5Cbegin%7Bcases%7D%20%5Cfrac%7Bx%5E2-x%7D%7Bx%7D%2C%26%20%5Ctext%7Bif%20%7D%20x%5Cgeq%201%5C%5C%200%2C%20%26%20%5Ctext%7Botherwise%7D%20%5Cend%7Bcases%7D%24%7D)
 
 <!--    f(x)= 
 \begin{cases}
@@ -703,7 +703,7 @@ function f (x) {
 
 一个例子就是 *sgn* 函数。这是 *正负号* 函数，或者叫 *符号* 函数。让我们用[分段函数](#分段函数)来描述它：
 
-![sgn](http://latex.codecogs.com/svg.latex?sgn%28x%29%20%3A%3D%20%5Cbegin%7Bcases%7D%20-1%26%20%5Ctext%7Bif%20%7D%20x%20%3C%200%5C%5C%200%2C%20%26%20%5Ctext%7Bif%20%7D%20%7Bx%20%3D%200%7D%5C%5C%201%2C%20%26%20%5Ctext%7Bif%20%7D%20x%20%3E%200%5C%5C%20%5Cend%7Bcases%7D)
+![sgn](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24sgn%28x%29%20%3A%3D%20%5Cbegin%7Bcases%7D%20-1%26%20%5Ctext%7Bif%20%7D%20x%20%3C%200%5C%5C%200%2C%20%26%20%5Ctext%7Bif%20%7D%20%7Bx%20%3D%200%7D%5C%5C%201%2C%20%26%20%5Ctext%7Bif%20%7D%20x%20%3E%200%5C%5C%20%5Cend%7Bcases%7D%24%7D)
 
 <!-- sgn(x) := 
 \begin{cases}
@@ -730,13 +730,13 @@ function sgn (x) {
 
 在某些著作中，函数可以被更明确的符号定义。例如，让我们回到之前提到的 `square` 函数。
 
-![function2](http://latex.codecogs.com/svg.latex?f%5Cleft%20%28x%20%5Cright%20%29%20%3D%20x%5E%7B2%7D)
+![function2](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24f%5Cleft%20%28x%20%5Cright%20%29%20%3D%20x%5E%7B2%7D%24%7D)
 
 <!-- f\left (x  \right ) = x^{2} -->
 
 也可以写为以下形式：
 
-![mapsto](http://latex.codecogs.com/svg.latex?f%20%3A%20x%20%5Cmapsto%20x%5E2)
+![mapsto](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24f%20%3A%20x%20%5Cmapsto%20x%5E2%24%7D)
 
 <!-- f : x \mapsto x^2 -->
 
@@ -744,7 +744,7 @@ function sgn (x) {
 
 有时，不是很常见，这个符号也用来描述函数的 *domain* 和 *codomain*。对 *ƒ* 更正式的定义可以写为：
 
-![funcnot](http://latex.codecogs.com/svg.latex?%5Cbegin%7Balign*%7D%20f%20%3A%26%5Cmathbb%7BR%7D%20%5Crightarrow%20%5Cmathbb%7BR%7D%5C%5C%20%26x%20%5Cmapsto%20x%5E2%20%5Cend%7Balign*%7D)
+![funcnot](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24%5Cbegin%7Balign*%7D%20f%20%3A%26%5Cmathbb%7BR%7D%20%5Crightarrow%20%5Cmathbb%7BR%7D%5C%5C%20%26x%20%5Cmapsto%20x%5E2%20%5Cend%7Balign*%7D%24%7D)
 
 <!-- \begin{align*}
 f :&\mathbb{R} \rightarrow \mathbb{R}\\
@@ -754,7 +754,7 @@ f :&\mathbb{R} \rightarrow \mathbb{R}\\
 
 函数的 *domain* 和 *codomain* 分别跟他的 *input* 和 *output* 类型有点像。这里有另一个例子，使用了我们之前输出整数的 *sgn* 函数。
 
-![domain2](http://latex.codecogs.com/svg.latex?sgn%20%3A%20%5Cmathbb%7BR%7D%20%5Crightarrow%20%5Cmathbb%7BZ%7D)
+![domain2](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24sgn%20%3A%20%5Cmathbb%7BR%7D%20%5Crightarrow%20%5Cmathbb%7BZ%7D%24%7D)
 
 <!-- sgn : \mathbb{R} \rightarrow \mathbb{Z} -->
 
@@ -790,13 +790,13 @@ function square (a) {
 
 对于一个[函数](#函数)，撇号通常描述为函数的 *导函数（derivative）* 。导函数会在未来的章节解释。我们来看一个之前的函数：
 
-![function2](http://latex.codecogs.com/svg.latex?f%5Cleft%20%28x%20%5Cright%20%29%20%3D%20x%5E%7B2%7D)
+![function2](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24f%5Cleft%20%28x%20%5Cright%20%29%20%3D%20x%5E%7B2%7D%24%7D)
 
 <!-- f\left (x  \right ) = x^{2} -->
 
 它的导函数（derivative）可以写为一个带撇号`′`的函数：
 
-![prime1](http://latex.codecogs.com/svg.latex?f%27%28x%29%20%3D%202x)
+![prime1](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24f%27%28x%29%20%3D%202x%24%7D)
 
 <!-- f'(x) = 2x -->
 
@@ -818,11 +818,11 @@ function fPrime (x) {
 
 `⌊x⌋` 和 `⌈x⌉` 这种特殊的括号分别用来表示*floor* 和 *ceil* 函数。 
 
-![floor](http://latex.codecogs.com/svg.latex?floor%28x%29%20%3D%20%5Clfloor%20x%20%5Crfloor)
+![floor](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24floor%28x%29%20%3D%20%5Clfloor%20x%20%5Crfloor%24%7D)
 
 <!-- floor(x) =  \lfloor x \rfloor -->
 
-![ceil](http://latex.codecogs.com/svg.latex?ceil%28x%29%20%3D%20%5Clceil%20x%20%5Crceil)
+![ceil](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24ceil%28x%29%20%3D%20%5Clceil%20x%20%5Crceil%24%7D)
 
 <!-- ceil(x) =  \lceil x \rceil -->
 
@@ -835,7 +835,7 @@ Math.ceil(x)
 
 当这两个符号混合`⌊x⌉`，它通常表示一个取整到最近的整数的函数。
 
-![round](http://latex.codecogs.com/svg.latex?round%28x%29%20%3D%20%5Clfloor%20x%20%5Crceil)
+![round](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24round%28x%29%20%3D%20%5Clfloor%20x%20%5Crceil%24%7D)
 
 <!-- round(x) =  \lfloor x \rceil -->
 
@@ -853,7 +853,7 @@ Math.round(x)
 
 `⇒` 和 `→` 优势被用作表示实质蕴涵（material implication）的逻辑。意思是如果A是true，那么B也是true。
 
-![material1](http://latex.codecogs.com/svg.latex?A%20%5CRightarrow%20B)
+![material1](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24A%20%5CRightarrow%20B%24%7D)
 
 <!-- A \Rightarrow B -->
 
@@ -867,7 +867,7 @@ if (A === true) {
 
 箭头可以是左右任何方向 `⇐` `⇒`，也可以双向`⇔`。当 *A ⇒ B* 并且 *B ⇒ A*，就是他们是相等的：
 
-![material-equiv](http://latex.codecogs.com/svg.latex?A%20%5CLeftrightarrow%20B)
+![material-equiv](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24A%20%5CLeftrightarrow%20B%24%7D)
 
 <!-- A \Leftrightarrow B -->
 
@@ -884,13 +884,13 @@ if (A === true) {
 
 偶尔会看到在这些符号上加了一条斜线，来表示 *不*，比如， *k* 不 "大于" *j*.
 
-![ngt](http://latex.codecogs.com/svg.latex?k%20%5Cngtr%20j)
+![ngt](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24k%20%5Cngtr%20j%24%7D)
 
 <!-- k \ngtr j -->
 
  `≪` 和 `≫`通常用来表示 *明显（significant）* 不相等。这是说 *k* 是有[数量级（order of magnitude）](https://en.wikipedia.org/wiki/Order_of_magnitude)的大于 *j*。
 
-![orderofmag](http://latex.codecogs.com/svg.latex?k%20%5Cgg%20j)
+![orderofmag](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24k%20%5Cgg%20j%24%7D)
 
 <!-- k \gg j -->
 
@@ -923,7 +923,7 @@ function orderOfMagnitude (n) {
 
 下边展示了与（conjunction）`∧`， 逻辑中的`AND`.
 
-![and](http://latex.codecogs.com/svg.latex?k%20%3E%202%20%5Cland%20k%20%3C%204%20%5CLeftrightarrow%20k%20%3D%203)
+![and](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24k%20%3E%202%20%5Cland%20k%20%3C%204%20%5CLeftrightarrow%20k%20%3D%203%24%7D)
 
 <!-- k > 2 \land k <  4 \Leftrightarrow k = 3   -->
 
@@ -945,7 +945,7 @@ if (k === 3) {
 
 下箭头 `∨` 是逻辑或（disjunction），就像 OR 操作符一样。
 
-![logic-or](http://latex.codecogs.com/svg.latex?A%20%5Clor%20B)
+![logic-or](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24A%20%5Clor%20B%24%7D)
 
 <!-- A \lor B -->
 
@@ -961,7 +961,7 @@ A || B
 
 这里是一个使用 *not* 符号简单的例子：
 
-![negation](http://latex.codecogs.com/svg.latex?x%20%5Cneq%20y%20%5CLeftrightarrow%20%5Clnot%28x%20%3D%20y%29)
+![negation](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24x%20%5Cneq%20y%20%5CLeftrightarrow%20%5Clnot%28x%20%3D%20y%29%24%7D)
 
 <!-- x \neq y \Leftrightarrow \lnot(x = y) -->
 
@@ -981,25 +981,25 @@ if (x !== y) {
 
 例如我们可以表示0和1之间的数，让他们包含或不包含0和1：
 
-- 不包含0或1： ![interval-opened-left-opened-right](http://latex.codecogs.com/svg.latex?%280%2C%201%29)
+- 不包含0或1： ![interval-opened-left-opened-right](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24%280%2C%201%29%24%7D)
 
 <!-- (0, 1) -->
 
-- 包含0但不包含1： ![interval-closed-left-opened-right](http://latex.codecogs.com/svg.latex?%5B0%2C%201%29)
+- 包含0但不包含1： ![interval-closed-left-opened-right](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24%5B0%2C%201%29%24%7D)
 
 <!-- [0, 1) -->
 
-- 不包含0但包含1： ![interval-opened-left-closed-right](http://latex.codecogs.com/svg.latex?%280%2C%201%5D)
+- 不包含0但包含1： ![interval-opened-left-closed-right](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24%280%2C%201%5D%24%7D)
 
 <!-- (0, 1] -->
 
-- 包含0和1： ![interval-closed-left-closed-right](http://latex.codecogs.com/svg.latex?%5B0%2C%201%5D)
+- 包含0和1： ![interval-closed-left-closed-right](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24%5B0%2C%201%5D%24%7D)
 
 <!-- [0, 1] -->
 
 例如我们指出一个点 `x` 在3D单位立方体中，我们可以说：
 
-![interval-unit-cube](http://latex.codecogs.com/svg.latex?x%20%5Cin%20%5B0%2C%201%5D%5E3)
+![interval-unit-cube](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24x%20%5Cin%20%5B0%2C%201%5D%5E3%24%7D)
 
 <!-- x \in [0, 1]^3 -->
 
@@ -1016,15 +1016,15 @@ var d = [0, 1]                                                // 闭区间
 
 区间与集合运算结合符使用：
 
-- *交集（intersection）* e.g. ![interval-intersection](http://latex.codecogs.com/svg.latex?%5B3%2C%205%29%20%5Ccap%20%5B4%2C%206%5D%20%3D%20%5B4%2C%205%29)
+- *交集（intersection）* e.g. ![interval-intersection](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24%5B3%2C%205%29%20%5Ccap%20%5B4%2C%206%5D%20%3D%20%5B4%2C%205%29%24%7D)
 
 <!-- [3, 5) \cap [4, 6] = [4, 5) -->
 
-- *并集（union）* e.g. ![interval-union](http://latex.codecogs.com/svg.latex?%5B3%2C%205%29%20%5Ccup%20%5B4%2C%206%5D%20%3D%20%5B3%2C%206%5D)
+- *并集（union）* e.g. ![interval-union](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24%5B3%2C%205%29%20%5Ccup%20%5B4%2C%206%5D%20%3D%20%5B3%2C%206%5D%24%7D)
 
 <!-- [3, 5) \cup [4, 6] = [3, 6] -->
 
-- *差集（difference）* e.g. ![interval-difference-1](http://latex.codecogs.com/svg.latex?%5B3%2C%205%29%20-%20%5B4%2C%206%5D%20%3D%20%5B3%2C%204%29) 还有 ![interval-difference-2](http://latex.codecogs.com/svg.latex?%5B4%2C%206%5D%20-%20%5B3%2C%205%29%20%3D%20%5B5%2C%206%5D)
+- *差集（difference）* e.g. ![interval-difference-1](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24%5B3%2C%205%29%20-%20%5B4%2C%206%5D%20%3D%20%5B3%2C%204%29%24%7D) 还有 ![interval-difference-2](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24%5B4%2C%206%5D%20-%20%5B3%2C%205%29%20%3D%20%5B5%2C%206%5D%24%7D)
 
 <!-- [3, 5) - [4, 6] = [3, 4) -->
 <!-- [4, 6] - [3, 5)  = [5, 6] -->

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ You might see the `:=`, `=:` and `=` symbols being used for *definition*.<sup>[1
 
 For example, the following defines *x* to be another name for 2*kj*.
 
-![equals1](http://latex.codecogs.com/svg.latex?x%20%3A%3D%202kj)
+![equals1](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24x%20%3A%3D%202kj%24%7D)
 
 <!-- x := 2kj -->
 
@@ -115,7 +115,7 @@ const f = (k, j) => 2 * k * j
 
 The following, on the other hand, represents equality:
 
-![equals2](http://latex.codecogs.com/svg.latex?x%20%3D%202kj)
+![equals2](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24x%20%3D%202kj%24%7D)
 
 <!-- x = 2kj -->
 
@@ -129,7 +129,7 @@ console.assert(x === (2 * k * j))
 
 A square root operation is of the form:
 
-![squareroot](http://latex.codecogs.com/svg.latex?%5Cleft%28%5Csqrt%7Bx%7D%5Cright%29%5E2%20%3D%20x)
+![squareroot](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24%5Cleft%28%5Csqrt%7Bx%7D%5Cright%29%5E2%20%3D%20x%24%7D)
 
 <!-- \left(\sqrt{x}\right)^2 = x -->
 
@@ -141,9 +141,9 @@ console.log(Math.sqrt(x));
 //=> 3
 ```
 
-Complex numbers are expressions of the form ![complex](http://latex.codecogs.com/svg.latex?a&space;&plus;&space;ib), where ![a](http://latex.codecogs.com/svg.latex?a) is the real part and ![b](http://latex.codecogs.com/svg.latex?b) is the imaginary part. The imaginary number ![i](http://latex.codecogs.com/svg.latex?i) is defined as:
+Complex numbers are expressions of the form ![complex](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24a&space;&plus;&space;ib%24%7D), where ![a](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24a%24%7D) is the real part and ![b](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24b%24%7D) is the imaginary part. The imaginary number ![i](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24i%24%7D) is defined as:
 
-![imaginary](http://latex.codecogs.com/svg.latex?i%3D%5Csqrt%7B-1%7D).
+![imaginary](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24i%3D%5Csqrt%7B-1%7D%24%7D).
 <!-- i=\sqrt{-1} -->
 
 In JavaScript, there is no built-in functionality for complex numbers, but there are some libraries that support complex number arithmetic. For example, using [mathjs](https://www.npmjs.com/package/mathjs):
@@ -184,7 +184,7 @@ They might seem obvious, but it's important to understand the subtle differences
 
 Both symbols can represent simple multiplication of scalars. The following are equivalent:
 
-![dotcross1](http://latex.codecogs.com/svg.latex?5%20%5Ccdot%204%20%3D%205%20%5Ctimes%204)
+![dotcross1](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%245%20%5Ccdot%204%20%3D%205%20%5Ctimes%204%24%7D)
 
 <!-- 5 \cdot 4 = 5 \times 4 -->
 
@@ -196,7 +196,7 @@ var result = 5 * 4
 
 Often, the multiplication sign is only used to avoid ambiguity (e.g. between two numbers). Here, we can omit it entirely:
 
-![dotcross2](http://latex.codecogs.com/svg.latex?3kj)
+![dotcross2](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%243kj%24%7D)
 
 <!-- 3kj -->
 
@@ -212,7 +212,7 @@ To denote multiplication of one vector with a scalar, or element-wise multiplica
 
 Let's take our earlier example but apply it to vectors. For element-wise vector multiplication, you might see an open dot `∘` to represent the [Hadamard product](https://en.wikipedia.org/wiki/Hadamard_product_%28matrices%29).<sup>[2]</sup>
 
-![dotcross3](http://latex.codecogs.com/svg.latex?3%5Cmathbf%7Bk%7D%5Ccirc%5Cmathbf%7Bj%7D)
+![dotcross3](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%243%5Cmathbf%7Bk%7D%5Ccirc%5Cmathbf%7Bj%7D%24%7D)
 
 <!-- 3\mathbf{k}\circ\mathbf{j} -->
 
@@ -248,7 +248,7 @@ Similarly, matrix multiplication typically does not use the dot `·` or cross sy
 
 The dot symbol `·` can be used to denote the [*dot product*](https://en.wikipedia.org/wiki/Dot_product) of two vectors. Sometimes this is called the *scalar product* since it evaluates to a scalar.
 
-![dotcross4](http://latex.codecogs.com/svg.latex?%5Cmathbf%7Bk%7D%5Ccdot%20%5Cmathbf%7Bj%7D)
+![dotcross4](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24%5Cmathbf%7Bk%7D%5Ccdot%20%5Cmathbf%7Bj%7D%24%7D)
 
 <!-- \mathbf{k}\cdot \mathbf{j} -->
 
@@ -274,7 +274,7 @@ function dot(a, b) {
 
 The cross symbol `×` can be used to denote the [*cross product*](https://en.wikipedia.org/wiki/Cross_product) of two vectors.
 
-![dotcross5](http://latex.codecogs.com/svg.latex?%5Cmathbf%7Bk%7D%5Ctimes%20%5Cmathbf%7Bj%7D)
+![dotcross5](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24%5Cmathbf%7Bk%7D%5Ctimes%20%5Cmathbf%7Bj%7D%24%7D)
 
 <!-- \mathbf{k}\times \mathbf{j} -->
 
@@ -314,7 +314,7 @@ For other implementations of vector multiplication, cross product, and dot produ
 
 The big Greek `Σ` (Sigma) is for [Summation](https://en.wikipedia.org/wiki/Summation). In other words: summing up some numbers.
 
-![sigma](http://latex.codecogs.com/svg.latex?%5Csum_%7Bi%3D1%7D%5E%7B100%7Di)
+![sigma](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24%5Csum_%7Bi%3D1%7D%5E%7B100%7Di%24%7D)
 
 <!-- \sum_{i=1}^{100}i -->
 
@@ -338,7 +338,7 @@ var sum = (n * (n + 1)) / 2
 
 Here is another example where the *i*, or the "what to sum," is different:
 
-![sum2](http://latex.codecogs.com/svg.latex?%5Csum_%7Bi%3D1%7D%5E%7B100%7D%282i&plus;1%29)
+![sum2](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24%5Csum_%7Bi%3D1%7D%5E%7B100%7D%282i&plus;1%29%24%7D)
 
 <!-- \sum_{i=1}^{100}(2i+1) -->
 
@@ -355,7 +355,7 @@ The result of `sum` is `10200`.
 
 The notation can be nested, which is much like nesting a `for` loop. You should evaluate the right-most sigma first, unless the author has enclosed them in parentheses to alter the order. However, in the following case, since we are dealing with finite sums, the order does not matter.
 
-![sigma3](http://latex.codecogs.com/svg.latex?%5Csum_%7Bi%3D1%7D%5E%7B2%7D%5Csum_%7Bj%3D4%7D%5E%7B6%7D%283ij%29)
+![sigma3](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24%5Csum_%7Bi%3D1%7D%5E%7B2%7D%5Csum_%7Bj%3D4%7D%5E%7B6%7D%283ij%29%24%7D)
 
 <!-- \sum_{i=1}^{2}\sum_{j=4}^{6}(3ij) -->
 
@@ -378,7 +378,7 @@ The capital Pi or "Big Pi" is very similar to [Sigma](#sigma), except we are usi
 
 Take the following:
 
-![capitalPi](http://latex.codecogs.com/svg.latex?%5Cprod_%7Bi%3D1%7D%5E%7B6%7Di)
+![capitalPi](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24%5Cprod_%7Bi%3D1%7D%5E%7B6%7Di%24%7D)
 
 <!-- \prod_{i=1}^{6}i -->
 
@@ -401,7 +401,7 @@ These three features all describe the *length* of an object.
 
 #### absolute value 
 
-![pipes1](http://latex.codecogs.com/svg.latex?%5Cleft%20%7C%20x%20%5Cright%20%7C)
+![pipes1](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24%5Cleft%20%7C%20x%20%5Cright%20%7C%24%7D)
 
 <!-- \left | x \right | -->
 
@@ -415,7 +415,7 @@ var result = Math.abs(x)
 
 #### Euclidean norm
 
-![pipes4](http://latex.codecogs.com/svg.latex?%5Cleft%20%5C%7C%20%5Cmathbf%7Bv%7D%20%5Cright%20%5C%7C)
+![pipes4](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24%5Cleft%20%5C%7C%20%5Cmathbf%7Bv%7D%20%5Cright%20%5C%7C%24%7D)
 
 <!-- \left \| \mathbf{v} \right \| -->
 
@@ -423,7 +423,7 @@ For a vector **v**, `‖v‖` is the [Euclidean norm](https://en.wikipedia.org/w
 
 Often this is represented by double-bars to avoid ambiguity with the *absolute value* notation, but sometimes you may see it with single bars:
 
-![pipes2](http://latex.codecogs.com/svg.latex?%5Cleft%20%7C%20%5Cmathbf%7Bv%7D%20%5Cright%20%7C)
+![pipes2](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24%5Cleft%20%7C%20%5Cmathbf%7Bv%7D%20%5Cright%20%7C%24%7D)
 
 <!-- \left | \mathbf{v} \right | -->
 
@@ -454,7 +454,7 @@ Other implementations:
 
 #### determinant
 
-![pipes3](http://latex.codecogs.com/svg.latex?%5Cleft%20%7C%5Cmathbf%7BA%7D%20%5Cright%20%7C)
+![pipes3](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24%5Cleft%20%7C%5Cmathbf%7BA%7D%20%5Cright%20%7C%24%7D)
 
 <!-- \left |\mathbf{A}  \right | -->
 
@@ -482,7 +482,7 @@ Implementations:
 
 In geometry, the "hat" symbol above a character is used to represent a [unit vector](https://en.wikipedia.org/wiki/Unit_vector). For example, here is the unit vector of **a**:
 
-![hat](http://latex.codecogs.com/svg.latex?%5Chat%7B%5Cmathbf%7Ba%7D%7D)
+![hat](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24%5Chat%7B%5Cmathbf%7Ba%7D%7D%24%7D)
 
 <!-- \hat{\mathbf{a}} -->
 
@@ -522,7 +522,7 @@ Other implementations:
 
 In set theory, the "element of" symbol `∈` and `∋` can be used to describe whether something is an element of a *set*. For example:
 
-![element1](http://latex.codecogs.com/svg.latex?A%3D%5Cleft%20%5C%7B3%2C9%2C14%7D%7B%20%5Cright%20%5C%7D%2C%203%20%5Cin%20A)
+![element1](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24A%3D%5Cleft%20%5C%7B3%2C9%2C14%7D%7B%20%5Cright%20%5C%7D%2C%203%20%5Cin%20A%24%7D)
 
 <!-- A=\left \{3,9,14}{  \right \}, 3 \in A -->
 
@@ -548,13 +548,13 @@ A.has(3)
 
 The backwards `∋` is the same, but the order changes:
 
-![element2](http://latex.codecogs.com/svg.latex?A%3D%5Cleft%20%5C%7B3%2C9%2C14%7D%7B%20%5Cright%20%5C%7D%2C%20A%20%5Cni%203)
+![element2](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24A%3D%5Cleft%20%5C%7B3%2C9%2C14%7D%7B%20%5Cright%20%5C%7D%2C%20A%20%5Cni%203%24%7D)
 
 <!-- A=\left \{3,9,14}{  \right \}, A \ni 3 -->
 
 You can also use the "not an element of" symbols `∉` and `∌` like so:
 
-![element3](http://latex.codecogs.com/svg.latex?A%3D%5Cleft%20%5C%7B3%2C9%2C14%7D%7B%20%5Cright%20%5C%7D%2C%206%20%5Cnotin%20A)
+![element3](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24A%3D%5Cleft%20%5C%7B3%2C9%2C14%7D%7B%20%5Cright%20%5C%7D%2C%206%20%5Cnotin%20A%24%7D)
 
 <!-- A=\left \{3,9,14}{  \right \}, 6 \notin A -->
 
@@ -564,7 +564,7 @@ You may see some some large [Blackboard](https://en.wikipedia.org/wiki/Blackboar
 
 For example, we might describe *k* to be an [element of](#element) the set `ℝ`. 
 
-![real](http://latex.codecogs.com/svg.latex?k%20%5Cin%20%5Cmathbb%7BR%7D)
+![real](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24k%20%5Cin%20%5Cmathbb%7BR%7D%24%7D)
 
 <!-- k \in \mathbb{R} -->
 
@@ -631,13 +631,13 @@ A complex number is a combination of a real and imaginary number, viewed as a co
 
 A function relates an input to an output value. For example, the following is a function:
 
-![function1](http://latex.codecogs.com/svg.latex?x%5E%7B2%7D)
+![function1](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24x%5E%7B2%7D%24%7D)
 
 <!-- x^{2} -->
 
 We can give this function a *name*. Commonly, we use `ƒ` to describe a function, but it could be named `A(x)` or anything else.
 
-![function2](http://latex.codecogs.com/svg.latex?f%5Cleft%20%28x%20%5Cright%20%29%20%3D%20x%5E%7B2%7D)
+![function2](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24f%5Cleft%20%28x%20%5Cright%20%29%20%3D%20x%5E%7B2%7D%24%7D)
 
 <!-- f\left (x  \right ) = x^{2} -->
 
@@ -651,7 +651,7 @@ function square (x) {
 
 Sometimes a function is not named, and instead the output is written.
 
-![function3](http://latex.codecogs.com/svg.latex?y%20%3D%20x%5E%7B2%7D)
+![function3](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24y%20%3D%20x%5E%7B2%7D%24%7D)
 
 <!-- y = x^{2} -->
 
@@ -659,7 +659,7 @@ In the above example, *x* is the input, the relationship is *squaring*, and *y* 
 
 Functions can also have multiple parameters, like in a programming language. These are known as *arguments* in mathematics, and the number of arguments a function takes is known as the *arity* of the function.
 
-![function4](http://latex.codecogs.com/svg.latex?f%28x%2Cy%29%20%3D%20%5Csqrt%7Bx%5E2%20&plus;%20y%5E2%7D)
+![function4](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24f%28x%2Cy%29%20%3D%20%5Csqrt%7Bx%5E2%20&plus;%20y%5E2%7D%24%7D)
 
 <!-- f(x,y) = \sqrt{x^2 + y^2} -->
 
@@ -677,7 +677,7 @@ Some functions will use different relationships depending on the input value, *x
 
 The following function *ƒ* chooses between two "sub functions" depending on the input value.
 
-![piecewise1](http://latex.codecogs.com/svg.latex?f%28x%29%3D%20%5Cbegin%7Bcases%7D%20%5Cfrac%7Bx%5E2-x%7D%7Bx%7D%2C%26%20%5Ctext%7Bif%20%7D%20x%5Cgeq%201%5C%5C%200%2C%20%26%20%5Ctext%7Botherwise%7D%20%5Cend%7Bcases%7D)
+![piecewise1](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24f%28x%29%3D%20%5Cbegin%7Bcases%7D%20%5Cfrac%7Bx%5E2-x%7D%7Bx%7D%2C%26%20%5Ctext%7Bif%20%7D%20x%5Cgeq%201%5C%5C%200%2C%20%26%20%5Ctext%7Botherwise%7D%20%5Cend%7Bcases%7D%24%7D)
 
 <!--    f(x)= 
 \begin{cases}
@@ -705,7 +705,7 @@ There are some function names that are ubiquitous in mathematics. For a programm
 
 One such example is the *sgn* function. This is the *signum* or *sign* function. Let's use [piecewise function](#piecewise-function) notation to describe it:
 
-![sgn](http://latex.codecogs.com/svg.latex?sgn%28x%29%20%3A%3D%20%5Cbegin%7Bcases%7D%20-1%26%20%5Ctext%7Bif%20%7D%20x%20%3C%200%5C%5C%200%2C%20%26%20%5Ctext%7Bif%20%7D%20%7Bx%20%3D%200%7D%5C%5C%201%2C%20%26%20%5Ctext%7Bif%20%7D%20x%20%3E%200%5C%5C%20%5Cend%7Bcases%7D)
+![sgn](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24sgn%28x%29%20%3A%3D%20%5Cbegin%7Bcases%7D%20-1%26%20%5Ctext%7Bif%20%7D%20x%20%3C%200%5C%5C%200%2C%20%26%20%5Ctext%7Bif%20%7D%20%7Bx%20%3D%200%7D%5C%5C%201%2C%20%26%20%5Ctext%7Bif%20%7D%20x%20%3E%200%5C%5C%20%5Cend%7Bcases%7D%24%7D)
 
 <!-- sgn(x) := 
 \begin{cases}
@@ -732,13 +732,13 @@ Other examples of such functions: *sin*, *cos*, *tan*.
 
 In some literature, functions may be defined with more explicit notation. For example, let's go back to the `square` function we mentioned earlier:
 
-![function2](http://latex.codecogs.com/svg.latex?f%5Cleft%20%28x%20%5Cright%20%29%20%3D%20x%5E%7B2%7D)
+![function2](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24f%5Cleft%20%28x%20%5Cright%20%29%20%3D%20x%5E%7B2%7D%24%7D)
 
 <!-- f\left (x  \right ) = x^{2} -->
 
 It might also be written in the following form:
 
-![mapsto](http://latex.codecogs.com/svg.latex?f%20%3A%20x%20%5Cmapsto%20x%5E2)
+![mapsto](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24f%20%3A%20x%20%5Cmapsto%20x%5E2%24%7D)
 
 <!-- f : x \mapsto x^2 -->
 
@@ -746,7 +746,7 @@ The arrow here with a tail typically means "maps to," as in *x maps to x<sup>2</
 
 Sometimes, when it isn't obvious, the notation will also describe the *domain* and *codomain* of the function. A more formal definition of *ƒ* might be written as:
 
-![funcnot](http://latex.codecogs.com/svg.latex?%5Cbegin%7Balign*%7D%20f%20%3A%26%5Cmathbb%7BR%7D%20%5Crightarrow%20%5Cmathbb%7BR%7D%5C%5C%20%26x%20%5Cmapsto%20x%5E2%20%5Cend%7Balign*%7D)
+![funcnot](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24%5Cbegin%7Balign*%7D%20f%20%3A%26%5Cmathbb%7BR%7D%20%5Crightarrow%20%5Cmathbb%7BR%7D%5C%5C%20%26x%20%5Cmapsto%20x%5E2%20%5Cend%7Balign*%7D%24%7D)
 
 <!-- \begin{align*}
 f :&\mathbb{R} \rightarrow \mathbb{R}\\
@@ -756,7 +756,7 @@ f :&\mathbb{R} \rightarrow \mathbb{R}\\
 
 A function's *domain* and *codomain* is a bit like its *input* and *output* types, respectively. Here's another example, using our earlier *sgn* function, which outputs an integer:
 
-![domain2](http://latex.codecogs.com/svg.latex?sgn%20%3A%20%5Cmathbb%7BR%7D%20%5Crightarrow%20%5Cmathbb%7BZ%7D)
+![domain2](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24sgn%20%3A%20%5Cmathbb%7BR%7D%20%5Crightarrow%20%5Cmathbb%7BZ%7D%24%7D)
 
 <!-- sgn : \mathbb{R} \rightarrow \mathbb{Z} -->
 
@@ -792,13 +792,13 @@ In code, we typically just assign the variable a more descriptive name, like `tr
 
 For a mathematical [function](#function), the prime symbol often describes the *derivative* of that function. Derivatives will be explained in a future section. Let's take our earlier function:
 
-![function2](http://latex.codecogs.com/svg.latex?f%5Cleft%20%28x%20%5Cright%20%29%20%3D%20x%5E%7B2%7D)
+![function2](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24f%5Cleft%20%28x%20%5Cright%20%29%20%3D%20x%5E%7B2%7D%24%7D)
 
 <!-- f\left (x  \right ) = x^{2} -->
 
 Its derivative could be written with a prime `′` symbol:
 
-![prime1](http://latex.codecogs.com/svg.latex?f%27%28x%29%20%3D%202x)
+![prime1](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24f%27%28x%29%20%3D%202x%24%7D)
 
 <!-- f'(x) = 2x -->
 
@@ -820,11 +820,11 @@ Multiple prime symbols can be used to describe the second derivative *ƒ′′* 
 
 The special brackets `⌊x⌋` and `⌈x⌉` represent the *floor* and *ceil* functions, respectively.
 
-![floor](http://latex.codecogs.com/svg.latex?floor%28x%29%20%3D%20%5Clfloor%20x%20%5Crfloor)
+![floor](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24floor%28x%29%20%3D%20%5Clfloor%20x%20%5Crfloor%24%7D)
 
 <!-- floor(x) =  \lfloor x \rfloor -->
 
-![ceil](http://latex.codecogs.com/svg.latex?ceil%28x%29%20%3D%20%5Clceil%20x%20%5Crceil)
+![ceil](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24ceil%28x%29%20%3D%20%5Clceil%20x%20%5Crceil%24%7D)
 
 <!-- ceil(x) =  \lceil x \rceil -->
 
@@ -837,7 +837,7 @@ Math.ceil(x)
 
 When the two symbols are mixed `⌊x⌉`, it typically represents a function that rounds to the nearest integer:
 
-![round](http://latex.codecogs.com/svg.latex?round%28x%29%20%3D%20%5Clfloor%20x%20%5Crceil)
+![round](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24round%28x%29%20%3D%20%5Clfloor%20x%20%5Crceil%24%7D)
 
 <!-- round(x) =  \lfloor x \rceil -->
 
@@ -855,7 +855,7 @@ Arrows are often used in [function notation](#function-notation). Here are a few
 
 Arrows like `⇒` and `→` are sometimes used in logic for *material implication.* That is, if A is true, then B is also true.
 
-![material1](http://latex.codecogs.com/svg.latex?A%20%5CRightarrow%20B)
+![material1](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24A%20%5CRightarrow%20B%24%7D)
 
 <!-- A \Rightarrow B -->
 
@@ -869,7 +869,7 @@ if (A === true) {
 
 The arrows can go in either direction `⇐` `⇒`, or both `⇔`. When *A ⇒ B* and *B ⇒ A*, they are said to be equivalent:
 
-![material-equiv](http://latex.codecogs.com/svg.latex?A%20%5CLeftrightarrow%20B)
+![material-equiv](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24A%20%5CLeftrightarrow%20B%24%7D)
 
 <!-- A \Leftrightarrow B -->
 
@@ -886,13 +886,13 @@ In math, the `<` `>` `≤` and `≥` are typically used in the same way we use t
 
 On rare occasions you might see a slash through these symbols, to describe *not*. As in, *k* is "not greater than" *j*.
 
-![ngt](http://latex.codecogs.com/svg.latex?k%20%5Cngtr%20j)
+![ngt](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24k%20%5Cngtr%20j%24%7D)
 
 <!-- k \ngtr j -->
 
 The `≪` and `≫` are sometimes used to represent *significant* inequality. That is, *k* is an [order of magnitude](https://en.wikipedia.org/wiki/Order_of_magnitude) larger than *j*.
 
-![orderofmag](http://latex.codecogs.com/svg.latex?k%20%5Cgg%20j)
+![orderofmag](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24k%20%5Cgg%20j%24%7D)
 
 <!-- k \gg j -->
 
@@ -925,7 +925,7 @@ Another use of arrows in logic is conjunction `∧` and disjunction `∨`. They 
 
 The following shows conjunction `∧`, the logical `AND`.
 
-![and](http://latex.codecogs.com/svg.latex?k%20%3E%202%20%5Cland%20k%20%3C%204%20%5CLeftrightarrow%20k%20%3D%203)
+![and](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24k%20%3E%202%20%5Cland%20k%20%3C%204%20%5CLeftrightarrow%20k%20%3D%203%24%7D)
 
 <!-- k > 2 \land k <  4 \Leftrightarrow k = 3   -->
 
@@ -947,7 +947,7 @@ if (k === 3) {
 
 The down arrow `∨` is logical disjunction, like the OR operator.
 
-![logic-or](http://latex.codecogs.com/svg.latex?A%20%5Clor%20B)
+![logic-or](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24A%20%5Clor%20B%24%7D)
 
 <!-- A \lor B -->
 
@@ -963,7 +963,7 @@ Occasionally, the `¬`, `~` and `!` symbols are used to represent logical `NOT`.
 
 Here is a simple example using the *not* symbol:
 
-![negation](http://latex.codecogs.com/svg.latex?x%20%5Cneq%20y%20%5CLeftrightarrow%20%5Clnot%28x%20%3D%20y%29)
+![negation](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24x%20%5Cneq%20y%20%5CLeftrightarrow%20%5Clnot%28x%20%3D%20y%29%24%7D)
 
 <!-- x \neq y \Leftrightarrow \lnot(x = y) -->
 
@@ -983,25 +983,25 @@ Sometimes a function deals with real numbers restricted to some range of values,
 
 For example we can represent the numbers between zero and one including/not including zero and/or one as:
 
-- Not including zero or one: ![interval-opened-left-opened-right](http://latex.codecogs.com/svg.latex?%280%2C%201%29)
+- Not including zero or one: ![interval-opened-left-opened-right](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24%280%2C%201%29%24%7D)
 
 <!-- (0, 1) -->
 
-- Including zero or but not one: ![interval-closed-left-opened-right](http://latex.codecogs.com/svg.latex?%5B0%2C%201%29)
+- Including zero or but not one: ![interval-closed-left-opened-right](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24%5B0%2C%201%29%24%7D)
 
 <!-- [0, 1) -->
 
-- Not including zero but including one: ![interval-opened-left-closed-right](http://latex.codecogs.com/svg.latex?%280%2C%201%5D)
+- Not including zero but including one: ![interval-opened-left-closed-right](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24%280%2C%201%5D%24%7D)
 
 <!-- (0, 1] -->
 
-- Including zero and one: ![interval-closed-left-closed-right](http://latex.codecogs.com/svg.latex?%5B0%2C%201%5D)
+- Including zero and one: ![interval-closed-left-closed-right](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24%5B0%2C%201%5D%24%7D)
 
 <!-- [0, 1] -->
 
 For example we to indicate that a point `x` is in the unit cube in 3D we say:
 
-![interval-unit-cube](http://latex.codecogs.com/svg.latex?x%20%5Cin%20%5B0%2C%201%5D%5E3)
+![interval-unit-cube](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24x%20%5Cin%20%5B0%2C%201%5D%5E3%24%7D)
 
 <!-- x \in [0, 1]^3 -->
 
@@ -1018,15 +1018,15 @@ var d = [0, 1]                                                // closed interval
 
 Intervals are used in conjunction with set operations:
 
-- *intersection* e.g. ![interval-intersection](http://latex.codecogs.com/svg.latex?%5B3%2C%205%29%20%5Ccap%20%5B4%2C%206%5D%20%3D%20%5B4%2C%205%29)
+- *intersection* e.g. ![interval-intersection](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24%5B3%2C%205%29%20%5Ccap%20%5B4%2C%206%5D%20%3D%20%5B4%2C%205%29%24%7D)
 
 <!-- [3, 5) \cap [4, 6] = [4, 5) -->
 
-- *union* e.g. ![interval-union](http://latex.codecogs.com/svg.latex?%5B3%2C%205%29%20%5Ccup%20%5B4%2C%206%5D%20%3D%20%5B3%2C%206%5D)
+- *union* e.g. ![interval-union](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24%5B3%2C%205%29%20%5Ccup%20%5B4%2C%206%5D%20%3D%20%5B3%2C%206%5D%24%7D)
 
 <!-- [3, 5) \cup [4, 6] = [3, 6] -->
 
-- *difference* e.g. ![interval-difference-1](http://latex.codecogs.com/svg.latex?%5B3%2C%205%29%20-%20%5B4%2C%206%5D%20%3D%20%5B3%2C%204%29) and ![interval-difference-2](http://latex.codecogs.com/svg.latex?%5B4%2C%206%5D%20-%20%5B3%2C%205%29%20%3D%20%5B5%2C%206%5D)
+- *difference* e.g. ![interval-difference-1](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24%5B3%2C%205%29%20-%20%5B4%2C%206%5D%20%3D%20%5B3%2C%204%29%24%7D) and ![interval-difference-2](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24%5B4%2C%206%5D%20-%20%5B3%2C%205%29%20%3D%20%5B5%2C%206%5D%24%7D)
 
 <!-- [3, 5) - [4, 6] = [3, 4) -->
 <!-- [4, 6] - [3, 5)  = [5, 6] -->


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Code style update
- [ ] Refactor (refactoring or adding test which isn't a fix or add a feature)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Did you test your solution?**

- [x] I lightly tested it in one browser
- [ ] I deeply tested it in several browsers
- [ ] I wrote tests around it (unit tests, integration tests, E2E tests)

## Problem Description

As mentioned in #85, the SVG images are invisible in dark mode. This is because they use a black foreground on a transparent background.

## Solution Description

The `\bg` instruction does not work with SVG in codecogs, but `\colorbox` does. This PR wraps each expression in a `\colorbox`. So `x = 2kj` becomes `\colorbox{white}{$x = 2kj$}`. 

For future reference, I used a sed oneliner to apply this to all instances: `sed -i -E 's|\]\(http://latex\.codecogs\.com/svg\.latex\?([^)]*)\)|](http://latex.codecogs.com/svg.latex?%5Ccolorbox%7Bwhite%7D%7B%24\1%24%7D)|g' input.md`

## Side Effects, Risks, Impact

The margin around the expression is slightly increased (in firefox at least). This fixes the dark mode legibility problem that @mwmwmw reported in #86, but in light mode it just means the margins are slightly bigger.